### PR TITLE
ensure old remote branch doesn't show up in local refs anymore

### DIFF
--- a/app/views/conversions/show.html.erb
+++ b/app/views/conversions/show.html.erb
@@ -11,7 +11,7 @@
     <code>
 git checkout <%= repo.conversion.old_default_branch_name %>
 git branch -m <%= repo.conversion.old_default_branch_name %> main
-git fetch
+git fetch --prune
 git branch --unset-upstream
 git branch -u origin/main
 git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main


### PR DESCRIPTION
After retrunk'ing, my local git history retained knowledge of `origin/<old_default_branch_name>`. This uses `--prune` to ensure its removal.